### PR TITLE
Expand README with project overview and dev guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,102 @@
-# シビックテックさいたまホームページ
-https://www.civictechsaitama.com/
+# シビックテックさいたま ホームページ
 
-## Build Setup
+公式サイト: https://www.civictechsaitama.com/
+
+このリポジトリは、シビックテックさいたまのWebサイトを管理するためのNuxtプロジェクトです。
+
+## シビックテックさいたまについて
+
+シビックテックさいたまは、市民・行政・地域コミュニティと連携しながら、
+デジタル技術を活用して地域課題に取り組むコミュニティです。
+
+このサイトでは、主に以下の情報を発信します。
+
+- 活動メッセージ
+- プロジェクト紹介
+- イベント情報
+- レポート・ニュース
+
+## 技術的要素のまとめ
+
+### アーキテクチャ
+
+- Nuxt 4 / Vue 3 ベースのサイト
+- `@nuxt/content` を用いたMarkdown中心のコンテンツ管理
+- 静的サイト生成（SSG）を前提に運用
+
+### 主な利用技術
+
+- `nuxt` `4.4.2`
+- `@nuxt/content` `3.x`
+- `@nuxt/image` `2.x`
+- `sass`
+- `vue-gtag-next`
+- `embla-carousel-vue` / `embla-carousel-autoplay`
+
+### コンテンツ管理
+
+- `content/` 配下のMarkdownをもとにページを生成
+- スキーマは `content.config.ts` で管理
+- 代表的なコンテンツ配置:
+	- `content/message.md`
+	- `content/projects.md`
+	- `content/vision.md`
+	- `content/data/`（イベント・活動ログ）
+
+### ビルド時処理
+
+- `npm run generate` / `yarn generate` で `scripts/generate.mjs` を経由して静的生成
+- 生成時に `nuxt.config.ts` のフックで `public/sitemap.xml` を更新
+- `public/CNAME` を参照してサイトURLを解決
+
+## 開発方法
+
+### 前提環境
+
+- Node.js `24.14.0`（`.node-version`）
+- npm または yarn（`packageManager` は yarn 1 系）
+
+### セットアップ
 
 ```bash
-# install dependencies
-$ npm i
-$ npm ci
-
-# serve with hot reload at localhost:3000
-$ npm run dev
-
-# generate static project
-$ npm run generate
+yarn install
 ```
+
+npmを使う場合:
+
+```bash
+npm install
+```
+
+### ローカル開発
+
+```bash
+yarn dev
+```
+
+ブラウザで `http://localhost:3000` を開いて確認します。
+
+### 本番ビルド
+
+```bash
+yarn build
+```
+
+### 静的サイト生成
+
+```bash
+yarn generate
+```
+
+### 生成物のローカル確認
+
+```bash
+yarn preview
+```
+
+## よく使う更新フロー
+
+1. `content/` 配下のMarkdownを追加・修正
+2. `yarn dev` で表示確認
+3. 必要に応じて `yarn generate` で生成結果を確認
+4. コミット・デプロイ


### PR DESCRIPTION
Augment README.md with a full project overview, site URL, and details about the Nuxt/Vue architecture, content management, and tech stack. Add development and build instructions (emphasizing yarn), Node version, common workflows (generate/preview), and examples for local development and static generation to help contributors get started.